### PR TITLE
Update Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ In your riemann.config
 
 (load-plugins) ; will load plugins from the classpath
 
-(rabbitmq-plugin/rabbitmq-consumer {
+(rabbitmq-plugin/amqp-consumer {
                        :parser-fn rabbitmq-plugin/logstash-parser ; message parsing function, the sample function here is the default
                        :prefetch-count 100 ; this is the default
                        :bindings [{


### PR DESCRIPTION
No found rabbitmq-plugin/rabbitmq-consumer, only [rabbitmq-plugin/amqp-consumer](https://github.com/WuLonghui/riemann-rabbitmq-plugin/blob/master/src/riemann_rabbitmq_plugin/core.clj#L109).
